### PR TITLE
Repo Name Change & Install Command Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A dual client/server side form data validation, transformation, and aggregation 
 
 ## Installation
 
-`mrt add Mesosphere`
+`meteor add copleykj:mesosphere`
 
 To include updates and bug fixes to Mesosphere in your project before they hit Atmosphere, update your projects smart.json to point to the beta branch on github.
 

--- a/package.js
+++ b/package.js
@@ -1,7 +1,7 @@
 Package.describe({
     summary: "A form-data validation and transformation package for Meteor",
-  version: "0.1.9",
-  git: "https://github.com/copleykj/Mesosphere.git"
+    version: "0.1.9",
+    git: "https://github.com/copleykj/mesosphere.git"
 });
 
 Package.on_use(function (api, where) {


### PR DESCRIPTION
Changes needed to update readme with proper installation instructions. Updated package.js with new github repo name.

In order for this to work with the new meteor package system the repository name name needs to be all lower case.

Please use `meteor publish` from within the project directory to publish the updated package.
